### PR TITLE
fix: cap API pagination bounds to prevent potential DoS

### DIFF
--- a/src/app/api/admin/prompts/route.ts
+++ b/src/app/api/admin/prompts/route.ts
@@ -24,8 +24,12 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "20");
+    const requestedPage = parseInt(searchParams.get("page") || "1");
+    const requestedLimit = parseInt(searchParams.get("limit") || "20");
+    
+    // Cap pagination to prevent database overload
+    const page = Math.max(1, requestedPage);
+    const limit = Math.min(Math.max(1, requestedLimit), 100);
     const search = searchParams.get("search") || "";
     const sortBy = searchParams.get("sortBy") || "createdAt";
     const sortOrder = searchParams.get("sortOrder") || "desc";

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -24,8 +24,12 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "20");
+    const requestedPage = parseInt(searchParams.get("page") || "1");
+    const requestedLimit = parseInt(searchParams.get("limit") || "20");
+    
+    // Cap pagination to prevent database overload
+    const page = Math.max(1, requestedPage);
+    const limit = Math.min(Math.max(1, requestedLimit), 100);
     const search = searchParams.get("search") || "";
     const sortBy = searchParams.get("sortBy") || "createdAt";
     const sortOrder = searchParams.get("sortOrder") || "desc";


### PR DESCRIPTION
## Description

Currently, the page and limit/perPage parameters are parsed directly from search parameters and passed to Prisma without any maximum constraint. A malicious actor could request perPage=1000000, causing large database payload extraction and potential DoS.

This PR implements a strict maximum 100 results per page threshold and ensures the requested page defaults sensibly across the public prompts list and the admin routes.

## Changes
- Added Math.min(..., 100) to public Prompt queries
- Added Math.min(..., 100) to admin User and Prompt queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pagination parameter validation across all API endpoints. Page values are now constrained to a minimum of 1, and limit/perPage values are clamped between 1 and 100. These improvements apply consistently to both public and admin API endpoints for uniform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->