### PR TITLE
fix(book): use completion token parameter for AI demos

### DIFF
--- a/src/__tests__/api/book-demo.test.ts
+++ b/src/__tests__/api/book-demo.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createCompletion } = vi.hoisted(() => ({
+  createCompletion: vi.fn(),
+}));
+
+vi.mock("openai", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: createCompletion,
+      },
+    },
+  })),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: vi.fn().mockResolvedValue({ features: { aiGeneration: true } }),
+}));
+
+import { POST } from "@/app/api/book/demo/route";
+
+describe("POST /api/book/demo", () => {
+  let originalApiKey: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalApiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "test-key";
+    createCompletion.mockResolvedValue({
+      choices: [{ message: { content: "A useful response" } }],
+    });
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    }
+  });
+
+  it("uses the current completion token parameter for run requests", async () => {
+    const request = new Request("http://localhost:3000/api/book/demo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "run_prompt", prompt: "Review this code" }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.result).toBe("A useful response");
+    expect(createCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_completion_tokens: 500,
+      }),
+    );
+    expect(createCompletion.mock.calls[0][0]).not.toHaveProperty("max_tokens");
+  });
+});

--- a/src/app/api/book/demo/route.ts
+++ b/src/app/api/book/demo/route.ts
@@ -174,6 +174,7 @@ Return JSON with this exact structure:
 }`
 };
 
+/** Process an interactive book AI demo request. */
 export async function POST(request: NextRequest) {
   const session = await auth();
   const isAuthenticated = !!session?.user;

--- a/src/app/api/book/demo/route.ts
+++ b/src/app/api/book/demo/route.ts
@@ -322,7 +322,7 @@ export async function POST(request: NextRequest) {
         { role: "user", content: userContent }
       ],
       temperature: type === "run_prompt" ? 0.7 : 0.3,
-      max_tokens: 500,
+      max_completion_tokens: 500,
       ...(responseFormat === "json_object" && { response_format: { type: "json_object" } }),
     });
 


### PR DESCRIPTION
Fixes #1258.\n\nThe interactive book demo sent the deprecated max_tokens option to Chat Completions. Modern reasoning models reject that option, causing both Run with AI and Chapter Challenge to return HTTP 500.\n\nThis changes the request to max_completion_tokens and adds a regression test for the request payload.\n\nValidation:\n- npm test: 45 files, 713 tests passed\n- npm run lint: exit 0, existing warnings only\n- git diff --check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced deprecated `max_tokens` with `max_completion_tokens` in `/api/book/demo`.
- Added a regression test for the request payload.
- Fixed “Failed to process request” errors in “Run with AI” and “Chapter Challenge.”
- 713 tests passed. Lint completed with existing warnings. `git diff --check` passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->